### PR TITLE
Change the event property names to align them with state properties

### DIFF
--- a/contracts/TrivialToken.sol
+++ b/contracts/TrivialToken.sol
@@ -31,7 +31,7 @@ contract TrivialToken is ERC223Token {
     uint256 public highestBid;
 
     //Events
-    event IcoStarted(uint256 endTime);
+    event IcoStarted(uint256 icoEndTime);
     event IcoContributed(address contributor, uint256 amountContributed, uint256 amountRaised);
     event IcoFinished(uint256 amountRaised);
     event AuctionStarted(uint256 auctionEndTime);


### PR DESCRIPTION
I've changed the event property names so that they will be the same as their public names - this will allow for easier data mapping on the front-end.